### PR TITLE
Added `InputState`.

### DIFF
--- a/src/Core.zig
+++ b/src/Core.zig
@@ -234,6 +234,8 @@ pub const MouseButton = enum {
     six,
     seven,
     eight,
+
+    pub const max = MouseButton.eight;
 };
 
 pub const Key = enum {
@@ -361,6 +363,8 @@ pub const Key = enum {
     grave,
 
     unknown,
+
+    pub const max = Key.unknown;
 };
 
 pub const KeyMods = packed struct(u8) {

--- a/src/InputState.zig
+++ b/src/InputState.zig
@@ -1,0 +1,54 @@
+const std = @import("std");
+const Core = @import("Core.zig");
+const ArrayBitSet = std.bit_set.ArrayBitSet;
+const IntegerBitSet = std.bit_set.IntegerBitSet;
+const KeyBitSet = ArrayBitSet(usize, @intFromEnum(Core.Key.max));
+const MouseButtonSet = IntegerBitSet(@intFromEnum(Core.MouseButton.max));
+const InputState = @This();
+
+keys: KeyBitSet = KeyBitSet.initEmpty(),
+mouse_buttons: MouseButtonSet = MouseButtonSet.initEmpty(),
+mouse_position: Core.Position = .{ .x = 0, .y = 0 },
+
+/// Updates the input state with the corresponding event.
+pub fn update(self: *InputState, ev: Core.Event) void {
+    switch (ev) {
+        .key_press => |k| self.keys.set(@intFromEnum(k.key)),
+        .key_release => |k| self.keys.unset(@intFromEnum(k.key)),
+        .mouse_motion => |mm| self.mouse_position = mm.pos,
+        .mouse_press => |mb| {
+            self.mouse_buttons.set(@intFromEnum(mb.button));
+            self.mouse_position = mb.pos;
+        },
+        .mouse_release => |mb| {
+            self.mouse_buttons.unset(@intFromEnum(mb.button));
+            self.mouse_position = mb.pos;
+        },
+        else => {},
+    }
+}
+
+/// Checks if the given key is held pressed.
+pub inline fn isKeyPressed(self: InputState, key: Core.Key) bool {
+    return self.keys.isSet(@intFromEnum(key));
+}
+
+/// Checks if the given key is released.
+pub inline fn isKeyReleased(self: InputState, key: Core.Key) bool {
+    return !self.isKeyPressed(key);
+}
+
+/// Checks if the given mouse button is held pressed.
+pub inline fn isMouseButtonPressed(self: InputState, button: Core.MouseButton) bool {
+    return self.mouse_buttons.isSet(@intFromEnum(button));
+}
+
+/// Checks if the given mouse button is released.
+pub inline fn isMouseButtonReleased(self: InputState, button: Core.MouseButton) bool {
+    return !self.isMouseButtonPressed(button);
+}
+
+/// Retreives the last known mouse position.
+pub inline fn getMousePosition(self: InputState) Core.Position {
+    return self.mouse_position;
+}

--- a/src/InputState.zig
+++ b/src/InputState.zig
@@ -1,9 +1,7 @@
 const std = @import("std");
 const Core = @import("Core.zig");
-const ArrayBitSet = std.bit_set.ArrayBitSet;
-const IntegerBitSet = std.bit_set.IntegerBitSet;
-const KeyBitSet = ArrayBitSet(usize, @intFromEnum(Core.Key.max));
-const MouseButtonSet = IntegerBitSet(@intFromEnum(Core.MouseButton.max));
+const KeyBitSet = std.StaticBitSet(@intFromEnum(Core.Key.max));
+const MouseButtonSet = std.StaticBitSet(@intFromEnum(Core.MouseButton.max));
 const InputState = @This();
 
 keys: KeyBitSet = KeyBitSet.initEmpty(),

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,5 +1,6 @@
 pub const Core = @import("Core.zig");
 pub const Timer = @import("Timer.zig");
+pub const InputState = @import("InputState.zig");
 pub const gpu = @import("gpu");
 pub const sysjs = @import("sysjs");
 const builtin = @import("builtin");


### PR DESCRIPTION
Adds the `InputState` structure that can be fed `Event`s to keep track of keys and mouse button states (pressed or released), and to keep track of the last known mouse position.

I took the liberty to add `Key.max` and `MouseButton.max` to define the upmost limit of a key/mouse button. That way if later on new keys or mouse buttons are added, `InputState` wont break and still works as expected (as long as `Key` and `MouseButton` remains exhaustive enums).

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.