### PR TITLE
Add joystick support

### DIFF
--- a/src/Core.zig
+++ b/src/Core.zig
@@ -156,18 +156,39 @@ pub fn cursorShape(core: *Core) CursorShape {
     return core.internal.cursorShape();
 }
 
+/// Checks if the given joystick is still connected.
 pub fn joystickPresent(core: *Core, joystick: Joystick) bool {
     return core.internal.joystickPresent(joystick);
 }
 
+/// Retreives the name of the joystick.
+/// Returns `null` if the joystick isnt connected.
 pub fn joystickName(core: *Core, joystick: Joystick) ?[:0]const u8 {
     return core.internal.joystickName(joystick);
 }
 
+/// Retrieves the state of the buttons of the given joystick. 
+/// A value of `true` indicates the button is pressed, `false` the button is released.
+/// No remapping is done, so the order of these buttons are joystick-dependent and should be
+/// consistent across platforms.
+/// 
+/// Returns `null` if the joystick isnt connected.
+/// 
+/// Note: For WebAssembly, the remapping is done directly by the web browser, so on that platform
+/// the order of these buttons might be different than on others.
 pub fn joystickButtons(core: *Core, joystick: Joystick) ?[]const bool {
     return core.internal.joystickButtons(joystick);
 }
 
+/// Retreives the state of the axes of the given joystick.
+/// The values are always from -1 to 1.
+/// No remapping is done, so the order of these axes are joytstick-dependent and should be 
+/// consistent acrsoss platforms.
+/// 
+/// Returns `null` if the joystick isnt connected.
+/// 
+/// Note: For WebAssembly, the remapping is done directly by the web browser, so on that platform
+/// the order of these axes might be different than on others.
 pub fn joystickAxes(core: *Core, joystick: Joystick) ?[]const f32 {
     return core.internal.joystickAxes(joystick);
 }

--- a/src/Core.zig
+++ b/src/Core.zig
@@ -156,6 +156,22 @@ pub fn cursorShape(core: *Core) CursorShape {
     return core.internal.cursorShape();
 }
 
+pub fn joystickPresent(core: *Core, joystick: Joystick) bool {
+    return core.internal.joystickPresent(joystick);
+}
+
+pub fn joystickName(core: *Core, joystick: Joystick) ?[:0]const u8 {
+    return core.internal.joystickName(joystick);
+}
+
+pub fn joystickButtons(core: *Core, joystick: Joystick) ?[]const bool {
+    return core.internal.joystickButtons(joystick);
+}
+
+pub fn joystickAxes(core: *Core, joystick: Joystick) ?[]const f32 {
+    return core.internal.joystickAxes(joystick);
+}
+
 pub fn adapter(core: *Core) *gpu.Adapter {
     return core.internal.adapter();
 }
@@ -208,6 +224,8 @@ pub const Event = union(enum) {
         xoffset: f32,
         yoffset: f32,
     },
+    joystick_connected: Joystick,
+    joystick_disconnected: Joystick,
     framebuffer_resize: Size,
     focus_gained,
     focus_lost,
@@ -420,3 +438,5 @@ pub const CursorShape = enum {
     resize_all,
     not_allowed,
 };
+
+pub const Joystick = enum(u8) {};

--- a/src/platform.zig
+++ b/src/platform.zig
@@ -46,6 +46,11 @@ comptime {
     assertHasDecl(@This().Core, "setCursorShape");
     assertHasDecl(@This().Core, "cursorShape");
 
+    assertHasDecl(@This().Core, "joystickPresent");
+    assertHasDecl(@This().Core, "joystickName");
+    assertHasDecl(@This().Core, "joystickButtons");
+    assertHasDecl(@This().Core, "joystickAxes");
+
     assertHasDecl(@This().Core, "adapter");
     assertHasDecl(@This().Core, "device");
     assertHasDecl(@This().Core, "swapChain");

--- a/src/platform/wasm/js.zig
+++ b/src/platform/wasm/js.zig
@@ -29,6 +29,9 @@ pub extern "mach" fn machSetCursorMode(canvas: CanvasId, mode: u32) void;
 pub extern "mach" fn machCursorMode(canvas: CanvasId) u32;
 pub extern "mach" fn machSetCursorShape(canvas: CanvasId, shape: u32) void;
 pub extern "mach" fn machCursorShape(canvas: CanvasId) u32;
+pub extern "mach" fn machJoystickName(idx: u8, dest: [*:0]u8, dest_len: usize) void;
+pub extern "mach" fn machJoystickButtons(idx: u8, dest: [*]u8, dest_len: usize) void;
+pub extern "mach" fn machJoystickAxes(idx: u8, dest: [*]f32, dest_len: usize) void;
 
 pub extern "mach" fn machShouldClose() bool;
 pub extern "mach" fn machHasEvent() bool;


### PR DESCRIPTION
Due to not being able to allocate memory within `Core.pollEvents`, the WASM backend statically allocate memory regarding the joystick's name, its button states, and its axis states. As such, a number of asumptions are made : 

- The maximum number of joysticks is 16 (in line with the GLFW backend).
- The maximum length of the joytick name is 64 characters.
- The maximum number of buttons is 32.
- The maximum number of axes is 16.

All of these values can be changed in `src/platform/wasm/Core.zig` by modifying the constants present in `JoystickData`.

This PR ignores gamepad remapping, and uses the joystick API of GLFW and assume web Gamepads are not remapped. This has the benefits of making the whole system straightforward to implement and both backend relatively similar (both just accesses a `[]bool` for buttons and a `[]f32` for axes). I also made that choice as GLFW's remapping is limited to 15 buttons only compared to 17 with web Gamepad. GLFW does not support left/right triggers as buttons or axes, but nowaday these buttons are present on almost every controllers.

In the futur, remapping could be implemented (I think in mach engine), which becomes a no-op on the WASM builds (as the browser already takes care of gamepad remapping).

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.