### PR TITLE
multi-threaded rendering w/input @ 240hz on dedicated thread

### DIFF
--- a/build_examples.zig
+++ b/build_examples.zig
@@ -69,10 +69,6 @@ pub fn build(
         .{ .name = "instanced-cube", .deps = &.{.zmath} },
         .{ .name = "advanced-gen-texture-light", .deps = &.{.zmath} },
         .{ .name = "fractal-cube", .deps = &.{.zmath} },
-        .{ .name = "textured-cube", .deps = &.{ .zmath, .zigimg, .assets } },
-        .{ .name = "sprite2d", .deps = &.{ .zmath, .zigimg, .assets } },
-        .{ .name = "image-blur", .deps = &.{ .zigimg, .assets } },
-        .{ .name = "cubemap", .deps = &.{ .zmath, .zigimg, .assets } },
         .{ .name = "map-async", .deps = &.{} },
         .{
             .name = "pbr-basic",
@@ -84,6 +80,10 @@ pub fn build(
             .deps = &.{ .zmath, .model3d, .assets },
             .std_platform_only = true,
         },
+        .{ .name = "textured-cube", .deps = &.{ .zmath, .zigimg, .assets } },
+        .{ .name = "sprite2d", .deps = &.{ .zmath, .zigimg, .assets } },
+        .{ .name = "image-blur", .deps = &.{ .zigimg, .assets } },
+        .{ .name = "cubemap", .deps = &.{ .zmath, .zigimg, .assets } },
     }) |example| {
         // FIXME: this is workaround for a problem that some examples
         // (having the std_platform_only=true field) as well as zigimg

--- a/examples/advanced-gen-texture-light/main.zig
+++ b/examples/advanced-gen-texture-light/main.zig
@@ -43,13 +43,13 @@ pub fn init(app: *App) !void {
     const eye = vec3(5.0, 7.0, 5.0);
     const target = vec3(0.0, 0.0, 0.0);
 
-    const size = app.core.framebufferSize();
-    const aspect_ratio = @as(f32, @floatFromInt(size.width)) / @as(f32, @floatFromInt(size.height));
+    const framebuffer = app.core.descriptor();
+    const aspect_ratio = @as(f32, @floatFromInt(framebuffer.width)) / @as(f32, @floatFromInt(framebuffer.height));
 
     app.queue = app.core.device().getQueue();
     app.cube = Cube.init(&app.core);
     app.light = Light.init(&app.core);
-    app.depth = Texture.depth(app.core.device(), size.width, size.height);
+    app.depth = Texture.depth(app.core.device(), framebuffer.width, framebuffer.height);
     app.camera = Camera.init(app.core.device(), eye, target, vec3(0.0, 1.0, 0.0), aspect_ratio, 45.0, 0.1, 100.0);
     app.keys = 0;
 }

--- a/examples/deferred-rendering/main.zig
+++ b/examples/deferred-rendering/main.zig
@@ -256,15 +256,15 @@ pub fn update(app: *App) !bool {
         }
     }
 
+    if (!app.is_paused) {
+        app.updateUniformBuffers();
+    }
+
     const command = try app.buildCommandBuffer();
     app.queue.submit(&[_]*gpu.CommandBuffer{command});
     command.release();
     app.core.swapChain().present();
     app.core.swapChain().getCurrentTextureView().?.release();
-
-    if (!app.is_paused) {
-        app.updateUniformBuffers();
-    }
 
     return false;
 }

--- a/examples/sprite2d/main.zig
+++ b/examples/sprite2d/main.zig
@@ -258,10 +258,10 @@ pub fn update(app: *App) !bool {
     try app.render();
 
     // Every second, update the window title with the FPS
+    // TODO: this is a terrible FPS calculation
     if (app.window_title_timer.read() >= 1.0) {
         app.window_title_timer.reset();
-        var buf: [32]u8 = undefined;
-        const title = try std.fmt.bufPrintZ(&buf, "Sprite2D [ FPS: {d} ]", .{@floor(1 / delta_time)});
+        const title = try std.fmt.bufPrintZ(&app.core.title, "Sprite2D [ FPS: {d} ]", .{@floor(1 / delta_time)});
         app.core.setTitle(title);
     }
     return false;

--- a/examples/textured-cube/main.zig
+++ b/examples/textured-cube/main.zig
@@ -290,10 +290,10 @@ pub fn update(app: *App) !bool {
     back_buffer_view.release();
 
     const delta_time = app.fps_timer.lap();
+    // TODO: this is a terrible FPS calculation
     if (app.window_title_timer.read() >= 1.0) {
         app.window_title_timer.reset();
-        var buf: [32]u8 = undefined;
-        const title = try std.fmt.bufPrintZ(&buf, "Textured Cube [ FPS: {d} ]", .{@floor(1 / delta_time)});
+        const title = try std.fmt.bufPrintZ(&app.core.title, "Textured Cube [ FPS: {d} ]", .{@floor(1 / delta_time)});
         app.core.setTitle(title);
     }
 

--- a/examples/triangle-msaa/main.zig
+++ b/examples/triangle-msaa/main.zig
@@ -124,10 +124,10 @@ pub fn update(app: *App) !bool {
     back_buffer_view.release();
 
     const delta_time = app.timer.lap();
+    // TODO: this is a terrible FPS calculation
     if (app.window_title_timer.read() >= 1.0) {
         app.window_title_timer.reset();
-        var buf: [32]u8 = undefined;
-        const title = try std.fmt.bufPrintZ(&buf, "Mach Core [ FPS: {d} ]", .{@floor(1 / delta_time)});
+        const title = try std.fmt.bufPrintZ(&app.core.title, "Mach Core [ FPS: {d} ]", .{@floor(1 / delta_time)});
         app.core.setTitle(title);
     }
     return false;

--- a/src/Core.zig
+++ b/src/Core.zig
@@ -9,7 +9,7 @@ internal: platform.Core,
 
 pub const Options = struct {
     is_app: bool = false,
-    is_headless: bool = false, // TODO: rename is_headless -> headless
+    headless: bool = false,
     // TODO: allow specifying display_mode, border
     // TODO: better window title lifetime management
     title: [*:0]const u8 = "Mach core",

--- a/src/Core.zig
+++ b/src/Core.zig
@@ -10,7 +10,8 @@ internal: platform.Core,
 pub const Options = struct {
     is_app: bool = false,
     headless: bool = false,
-    // TODO: allow specifying display_mode, border
+    display_mode: DisplayMode = .windowed,
+    border: bool = true,
     // TODO: better window title lifetime management
     title: [*:0]const u8 = "Mach core",
     size: Size = .{ .width = 1920 / 2, .height = 1080 / 2 },

--- a/src/Core.zig
+++ b/src/Core.zig
@@ -51,11 +51,6 @@ pub inline fn pollEvents(core: *Core) EventIterator {
     return .{ .internal = core.internal.pollEvents() };
 }
 
-/// Returns the framebuffer size, in subpixel units.
-pub fn framebufferSize(core: *Core) Size {
-    return core.internal.framebufferSize();
-}
-
 /// Sets seconds to wait for an event with timeout when calling `Core.update()`
 /// again.
 ///
@@ -73,7 +68,7 @@ pub fn setWaitTimeout(core: *Core, timeout: f64) void {
 
 /// Sets the window title. The string must be owned by Core, and will not be copied or freed. It is
 /// advised to use the Core.title buffer for this purpose, e.g.:
-/// 
+///
 /// ```
 /// const title = try std.fmt.bufPrintZ(&core.title, "Hello, world!", .{});
 /// core.setTitle(title);

--- a/src/Core.zig
+++ b/src/Core.zig
@@ -244,6 +244,17 @@ pub fn descriptor(core: *Core) gpu.SwapChain.Descriptor {
     return core.internal.descriptor();
 }
 
+/// Whether mach core has run out of memory. If true, freeing memory should restore it to a
+/// functional state.
+///
+/// Once called, future calls will return false until another OOM error occurs.
+///
+/// Note that if an App.update function returns any error, including errors.OutOfMemory, it will
+/// exit the application.
+pub fn outOfMemory(core: *Core) bool {
+    return core.internal.outOfMemory();
+}
+
 pub const Size = struct {
     width: u32,
     height: u32,

--- a/src/Core.zig
+++ b/src/Core.zig
@@ -9,7 +9,9 @@ internal: platform.Core,
 
 pub const Options = struct {
     is_app: bool = false,
-    is_headless: bool = false,
+    is_headless: bool = false, // TODO: rename is_headless -> headless
+    // TODO: allow specifying display_mode, border
+    // TODO: better window title lifetime management
     title: [*:0]const u8 = "Mach core",
     size: Size = .{ .width = 1920 / 2, .height = 1080 / 2 },
     power_preference: gpu.PowerPreference = .undefined,
@@ -235,13 +237,26 @@ pub const Size = struct {
 };
 
 pub const SizeOptional = struct {
-    width: ?u32,
-    height: ?u32,
+    width: ?u32 = null,
+    height: ?u32 = null,
+
+    pub inline fn equals(a: SizeOptional, b: SizeOptional) bool {
+        if ((a.width != null) != (b.width != null)) return false;
+        if ((a.height != null) != (b.height != null)) return false;
+
+        if (a.width != null and a.width.? != b.width.?) return false;
+        if (a.height != null and a.height.? != b.height.?) return false;
+        return true;
+    }
 };
 
 pub const SizeLimit = struct {
     min: SizeOptional,
     max: SizeOptional,
+
+    pub inline fn equals(a: SizeLimit, b: SizeLimit) bool {
+        return a.min.equals(b.min) and a.max.equals(b.max);
+    }
 };
 
 pub const Position = struct {

--- a/src/platform.zig
+++ b/src/platform.zig
@@ -17,7 +17,6 @@ comptime {
     assertHasDecl(@This().Core, "init");
     assertHasDecl(@This().Core, "deinit");
     assertHasDecl(@This().Core, "pollEvents");
-    assertHasDecl(@This().Core, "framebufferSize");
 
     assertHasDecl(@This().Core, "setWaitTimeout");
     assertHasDecl(@This().Core, "setTitle");

--- a/src/platform.zig
+++ b/src/platform.zig
@@ -60,6 +60,7 @@ comptime {
     assertHasDecl(@This().Core, "device");
     assertHasDecl(@This().Core, "swapChain");
     assertHasDecl(@This().Core, "descriptor");
+    assertHasDecl(@This().Core, "outOfMemory");
 
     // Timer
     assertHasDecl(@This().Timer, "start");

--- a/src/platform/native/Core.zig
+++ b/src/platform/native/Core.zig
@@ -109,7 +109,7 @@ const UserPtr = struct {
     self: *Core,
 };
 
-// TODO(core): expose device loss to users, this can happen especially in the web and on mobile
+// TODO(important): expose device loss to users, this can happen especially in the web and on mobile
 // devices. Users will need to re-upload all assets to the GPU in this event.
 fn deviceLostCallback(reason: gpu.Device.LostReason, msg: [*:0]const u8, userdata: ?*anyopaque) callconv(.C) void {
     _ = userdata;
@@ -234,7 +234,6 @@ pub fn init(core: *Core, allocator: std.mem.Allocator, options: Options) !void {
     var events = EventQueue.init(allocator);
     try events.ensureTotalCapacity(2048);
 
-    // TODO: order according to struct fields
     core.* = .{
         .allocator = allocator,
         .window = window,
@@ -453,7 +452,7 @@ fn initCallbacks(self: *Core) void {
 }
 
 fn pushEvent(self: *Core, event: Event) void {
-    // TODO(core): handle OOM via error flag
+    // TODO(oom): handle OOM via error flag
     self.events_mu.lock();
     defer self.events_mu.unlock();
     self.events.writeItem(event) catch unreachable;
@@ -500,7 +499,7 @@ pub fn appUpdateThread(self: *Core, app: anytype) void {
             });
         }
 
-        // TODO: pass error back via update() call
+        // TODO(important): pass error back via update() call
         if (app.update() catch unreachable) return;
         self.gpu_device.tick();
     }
@@ -541,7 +540,7 @@ pub fn update(self: *Core, app: anytype) !bool {
                     );
                 },
                 .fullscreen => {
-                    // TODO: restoration of original window size/position
+                    // TODO(feature): restoration of original window size/position
                     // if (self.last_display_mode == .windowed) {
                     //     self.last_size = self.window.getSize();
                     //     self.last_pos = self.window.getPos();
@@ -549,7 +548,7 @@ pub fn update(self: *Core, app: anytype) !bool {
 
                     const monitor = blk: {
                         if (monitor_index) |i| {
-                            // TODO(core): handle OOM via error flag
+                            // TODO(oom): handle OOM via error flag
                             const monitor_list = glfw.Monitor.getAll(self.allocator) catch unreachable;
                             defer self.allocator.free(monitor_list);
                             break :blk monitor_list[i];
@@ -564,7 +563,7 @@ pub fn update(self: *Core, app: anytype) !bool {
                     }
                 },
                 .borderless => {
-                    // TODO: restoration of original window size/position
+                    // TODO(feature): restoration of original window size/position
                     // if (self.last_display_mode == .windowed) {
                     //     self.last_size = self.window.getSize();
                     //     self.last_pos = self.window.getPos();
@@ -572,7 +571,7 @@ pub fn update(self: *Core, app: anytype) !bool {
 
                     const monitor = blk: {
                         if (monitor_index) |i| {
-                            // TODO(core): handle OOM via error flag
+                            // TODO(oom): handle OOM via error flag
                             const monitor_list = glfw.Monitor.getAll(self.allocator) catch unreachable;
                             defer self.allocator.free(monitor_list);
                             break :blk monitor_list[i];
@@ -635,7 +634,7 @@ pub fn update(self: *Core, app: anytype) !bool {
         // Cursor shape changes
         if (self.current_cursor_shape != self.last_cursor_shape) {
             self.last_cursor_shape = self.current_cursor_shape;
-            // TODO: creating a GLFW standard cursor could fail, we should provide custom backup
+            // TODO(feature): creating a GLFW standard cursor could fail, we should provide custom backup
             // images for these. https://github.com/hexops/mach/pull/352
             const enum_int = @intFromEnum(self.current_cursor_shape);
             const tried = self.cursors_tried[enum_int];
@@ -659,15 +658,14 @@ pub fn update(self: *Core, app: anytype) !bool {
                 self.window.setCursor(cur);
             } else {
                 glfw.getErrorCode() catch {}; // discard error
-                // TODO: creating a GLFW standard cursor could fail, we should provide custom backup
+                // TODO(feature): creating a GLFW standard cursor could fail, we should provide custom backup
                 // images for these. https://github.com/hexops/mach/pull/352
                 log.warn("mach: setCursorShape: {s} not yet supported\n", .{@tagName(self.current_cursor_shape)});
             }
         }
     }
 
-    // TODO: allow configurable wait period here
-    // TODO: instead of pushEvent locking/unlocking, consider grabbing mutex here?
+    // TODO(important): allow configurable wait period here
     glfw.waitEventsTimeout(1.0 / 240.0);
 
     glfw.getErrorCode() catch |err| switch (err) {
@@ -684,15 +682,14 @@ pub fn update(self: *Core, app: anytype) !bool {
 
 // May be called from any thread.
 pub inline fn pollEvents(self: *Core) EventIterator {
-    // TODO: block for wait_timeout
+    // TODO(feature): implement wait_timeout
     return EventIterator{ .events_mu = &self.events_mu, .queue = &self.events };
 }
 
 // May be called from any thread.
 pub fn setWaitTimeout(self: *Core, timeout: f64) void {
-    // TODO: thread-safety
-    // TODO: reimplement wait_timeout
-    self.wait_timeout = timeout;
+    // TODO(feature): implement wait_timeout
+    // self.wait_timeout = timeout;
 }
 
 // May be called from any thread.

--- a/src/platform/native/Core.zig
+++ b/src/platform/native/Core.zig
@@ -224,7 +224,7 @@ pub fn init(core: *Core, allocator: std.mem.Allocator, options: Options) !void {
         .format = .bgra8_unorm,
         .width = framebuffer_size.width,
         .height = framebuffer_size.height,
-        .present_mode = .fifo, // TODO: verify this is the present mode we want by default
+        .present_mode = .mailbox,
     };
     const swap_chain = gpu_device.createSwapChain(surface, &swap_chain_desc);
 

--- a/src/platform/native/Core.zig
+++ b/src/platform/native/Core.zig
@@ -136,7 +136,7 @@ pub fn init(core: *Core, allocator: std.mem.Allocator, options: Options) !void {
     // Create the test window and discover adapters using it (esp. for OpenGL)
     var hints = util.glfwWindowHintsForBackend(backend_type);
     hints.cocoa_retina_framebuffer = true;
-    if (options.is_headless) {
+    if (options.headless) {
         hints.visible = false; // Hiding window before creation otherwise you get the window showing up for a little bit then hiding.
     }
 
@@ -271,7 +271,7 @@ pub fn init(core: *Core, allocator: std.mem.Allocator, options: Options) !void {
     core.current_border = true; // options.border TODO
     core.last_border = core.current_border;
 
-    core.current_headless = options.is_headless;
+    core.current_headless = options.headless;
     core.last_headless = core.current_headless;
 
     const actual_size = core.window.getSize();

--- a/src/platform/native/Core.zig
+++ b/src/platform/native/Core.zig
@@ -268,8 +268,11 @@ pub fn init(core: *Core, allocator: std.mem.Allocator, options: Options) !void {
     core.current_title = ""; // options.title
     core.last_title = core.current_title;
 
-    core.current_border = true; // options.border TODO
-    core.last_border = core.current_border;
+    core.current_display_mode = options.display_mode;
+    core.last_display_mode = .windowed;
+
+    core.current_border = options.border;
+    core.last_border = true;
 
     core.current_headless = options.headless;
     core.last_headless = core.current_headless;

--- a/src/platform/native/Core.zig
+++ b/src/platform/native/Core.zig
@@ -724,7 +724,7 @@ pub fn setDisplayMode(self: *Core, mode: DisplayMode, monitor_index: ?usize) voi
     defer self.state_mu.unlock();
     self.current_display_mode = mode;
     self.current_monitor_index = monitor_index;
-    self.state_update.set(); // TODO: only set if changed from last
+    if (self.current_display_mode != self.last_display_mode) self.state_update.set();
 }
 
 // May be called from any thread.
@@ -739,7 +739,7 @@ pub fn setBorder(self: *Core, value: bool) void {
     self.state_mu.lock();
     defer self.state_mu.unlock();
     self.current_border = value;
-    self.state_update.set(); // TODO: only set if changed from last
+    if (self.current_border != self.last_border) self.state_update.set();
 }
 
 // May be called from any thread.
@@ -754,7 +754,7 @@ pub fn setHeadless(self: *Core, value: bool) void {
     self.state_mu.lock();
     defer self.state_mu.unlock();
     self.current_headless = value;
-    self.state_update.set(); // TODO: only set if changed from last
+    if (self.current_headless != self.last_headless) self.state_update.set();
 }
 
 // May be called from any thread.
@@ -792,7 +792,7 @@ pub fn setSize(self: *Core, value: Size) void {
     self.state_mu.lock();
     defer self.state_mu.unlock();
     self.current_size = value;
-    self.state_update.set(); // TODO: only set if changed from last
+    if (self.current_size != self.last_size) self.state_update.set();
 }
 
 // May be called from any thread.
@@ -807,7 +807,7 @@ pub fn setSizeLimit(self: *Core, limit: SizeLimit) void {
     self.state_mu.lock();
     defer self.state_mu.unlock();
     self.current_size_limit = limit;
-    self.state_update.set(); // TODO: only set if changed from last
+    if (!self.current_size_limit.equal(self.last_size_limit)) self.state_update.set();
 }
 
 // May be called from any thread.
@@ -822,7 +822,7 @@ pub fn setCursorMode(self: *Core, mode: CursorMode) void {
     self.state_mu.lock();
     defer self.state_mu.unlock();
     self.current_cursor_mode = mode;
-    self.state_update.set();
+    if (self.current_cursor_mode != self.last_cursor_mode) self.state_update.set();
 }
 
 // May be called from any thread.
@@ -837,7 +837,7 @@ pub fn setCursorShape(self: *Core, shape: CursorShape) void {
     self.state_mu.lock();
     defer self.state_mu.unlock();
     self.current_cursor_shape = shape;
-    self.state_update.set();
+    if (self.current_cursor_shape != self.last_cursor_shape) self.state_update.set();
 }
 
 // May be called from any thread.

--- a/src/platform/native/Core.zig
+++ b/src/platform/native/Core.zig
@@ -280,10 +280,10 @@ pub fn init(core: *Core, allocator: std.mem.Allocator, options: Options) !void {
     const actual_size = core.window.getSize();
     core.current_size = .{ .width = actual_size.width, .height = actual_size.height };
     core.last_size = core.current_size;
+    core.state_update.set();
 
     core_instance = core;
     core.user_ptr = .{ .self = core };
-    core.setSizeLimit(core.current_size_limit);
 
     core.initCallbacks();
 

--- a/src/platform/native/Core.zig
+++ b/src/platform/native/Core.zig
@@ -668,7 +668,7 @@ pub fn update(self: *Core, app: anytype) !bool {
 
     // TODO: allow configurable wait period here
     // TODO: instead of pushEvent locking/unlocking, consider grabbing mutex here?
-    glfw.waitEventsTimeout(1.0/240.0);
+    glfw.waitEventsTimeout(1.0 / 240.0);
 
     glfw.getErrorCode() catch |err| switch (err) {
         error.PlatformError => log.err("glfw: failed to poll events", .{}),
@@ -686,18 +686,6 @@ pub fn update(self: *Core, app: anytype) !bool {
 pub inline fn pollEvents(self: *Core) EventIterator {
     // TODO: block for wait_timeout
     return EventIterator{ .events_mu = &self.events_mu, .queue = &self.events };
-}
-
-// TODO: one of descriptor() or framebufferSize() should go away.
-
-// May be called from any thread.
-// TODO: thread-safety
-pub fn framebufferSize(self: *Core) Size {
-    const framebuffer_size = self.window.getFramebufferSize();
-    return .{
-        .width = framebuffer_size.width,
-        .height = framebuffer_size.height,
-    };
 }
 
 // May be called from any thread.

--- a/src/platform/native/Core.zig
+++ b/src/platform/native/Core.zig
@@ -91,8 +91,6 @@ last_cursor_shape: CursorShape = .arrow,
 // Mutable fields protected by mutex.
 wait_timeout: f64 = 0.0,
 last_pos: glfw.Window.Pos,
-display_mode: DisplayMode,
-border: bool = true,
 
 const EventQueue = std.fifo.LinearFifo(Event, .Dynamic);
 
@@ -257,7 +255,6 @@ pub fn init(core: *Core, allocator: std.mem.Allocator, options: Options) !void {
         .current_size = undefined,
         .last_size = undefined,
         .last_pos = window.getPos(),
-        .display_mode = .windowed,
         .cursors = std.mem.zeroes([@typeInfo(CursorShape).Enum.fields.len]?glfw.Cursor),
         .cursors_tried = std.mem.zeroes([@typeInfo(CursorShape).Enum.fields.len]bool),
         .present_joysticks = std.StaticBitSet(@typeInfo(glfw.Joystick.Id).Enum.fields.len).initEmpty(),
@@ -529,9 +526,10 @@ pub fn update(self: *Core, app: anytype) !bool {
         // Display mode changes
         if (self.current_display_mode != self.last_display_mode) {
             const monitor_index = self.current_monitor_index;
+            const current_border = self.current_border;
             switch (self.current_display_mode) {
                 .windowed => {
-                    self.window.setAttrib(.decorated, self.border);
+                    self.window.setAttrib(.decorated, current_border);
                     self.window.setAttrib(.floating, false);
                     self.window.setMonitor(
                         null,

--- a/src/platform/native/entry.zig
+++ b/src/platform/native/entry.zig
@@ -33,6 +33,6 @@ pub fn main() !void {
     defer app.deinit();
 
     while (true) {
-        if (try app.update()) return;
+        if (try app.core.internal.update(&app)) return;
     }
 }

--- a/src/platform/wasm/Core.zig
+++ b/src/platform/wasm/Core.zig
@@ -395,6 +395,11 @@ pub fn descriptor(self: *Core) gpu.SwapChain.Descriptor {
     };
 }
 
+pub fn outOfMemory(self: *Core) bool {
+    _ = self;
+    return false;
+}
+
 fn toMachButton(button: i32) MouseButton {
     return switch (button) {
         0 => .left,

--- a/src/platform/wasm/Core.zig
+++ b/src/platform/wasm/Core.zig
@@ -218,13 +218,6 @@ pub inline fn pollEvents(self: *Core) EventIterator {
     };
 }
 
-pub fn framebufferSize(self: *Core) Size {
-    return .{
-        .width = js.machCanvasFramebufferWidth(self.id),
-        .height = js.machCanvasFramebufferHeight(self.id),
-    };
-}
-
 pub fn setWaitTimeout(_: *Core, timeout: f64) void {
     js.machSetWaitTimeout(timeout);
 }
@@ -233,8 +226,9 @@ pub fn setTitle(self: *Core, title: [:0]const u8) void {
     js.machCanvasSetTitle(self.id, title.ptr, title.len);
 }
 
-pub fn setDisplayMode(self: *Core, mode: DisplayMode, monitor: ?usize) void {
+pub fn setDisplayMode(self: *Core, _mode: DisplayMode, monitor: ?usize) void {
     _ = monitor;
+    var mode = _mode;
     if (mode == .borderless) {
         // borderless fullscreen window has no meaning in web
         mode = .fullscreen;
@@ -390,8 +384,15 @@ pub fn swapChain(_: *Core) *gpu.SwapChain {
     unreachable;
 }
 
-pub fn descriptor(_: *Core) gpu.SwapChain.Descriptor {
-    unreachable;
+pub fn descriptor(self: *Core) gpu.SwapChain.Descriptor {
+    return .{
+        .label = "main swap chain",
+        .usage = .{ .render_attachment = true },
+        .format = .bgra8_unorm, // TODO: is this correct?
+        .width = js.machCanvasFramebufferWidth(self.id),
+        .height = js.machCanvasFramebufferHeight(self.id),
+        .present_mode = .fifo, // TODO: https://github.com/gpuweb/gpuweb/issues/1224
+    };
 }
 
 fn toMachButton(button: i32) MouseButton {

--- a/src/platform/wasm/Timer.zig
+++ b/src/platform/wasm/Timer.zig
@@ -10,7 +10,7 @@ pub fn start() !Timer {
 }
 
 pub fn read(timer: *Timer) u64 {
-    return (js.machPerfNow() - timer.initial) * std.time.ns_per_ms;
+    return @intFromFloat((js.machPerfNow() - timer.initial) * std.time.ns_per_ms);
 }
 
 pub fn reset(timer: *Timer) void {


### PR DESCRIPTION
This adds support for multi-threaded rendering, where `App.update` is called in a separate thread on native platforms and the main thread is reserved for input event handling.

This means:

1. `App.init` and `App.deinit` are executed on the main thread, `App.update` is executed in a separate thread.
2. Without you really knowing or having to do anything different, we benefit from multi-threading in platforms that support it and still support platforms that do not (e.g. browsers.)
3. Input events are enqueued/bufferred, and you can poll them whenever you like (e.g. you may handle input mid-frame if you like.)
4. You can e.g. have rendering at 60hz while input handling is happening at 240hz

Perhaps best of all, we get butter-smooth rendering while resizing windows too:

https://github.com/hexops/mach-core/assets/3173176/e5c1014c-5bd7-4c2a-9891-225179c4eb3c

Will need to be resolved later:

1. Joystick API; I would like to rename it to `controller` and it needs to be adapted to a multi-threaded model.
2. setWaitTimeout / "waiting"; e.g. if you have a desktop application that you rightfully want to be low-power, in this scenario you need a way to slow event polling of both the main thread and rendering thread.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.