### PR TITLE
Core: Set `shouldClose` to false deferring control to the user.

### DIFF
--- a/src/platform/native/Core.zig
+++ b/src/platform/native/Core.zig
@@ -684,6 +684,7 @@ pub fn update(self: *Core, app: anytype) !bool {
 
     if (self.window.shouldClose()) {
         self.pushEvent(.close);
+        self.window.setShouldClose(false);
     }
     return false;
 }

--- a/src/platform/native/Core.zig
+++ b/src/platform/native/Core.zig
@@ -683,8 +683,8 @@ pub fn update(self: *Core, app: anytype) !bool {
     };
 
     if (self.window.shouldClose()) {
-        self.pushEvent(.close);
         self.window.setShouldClose(false);
+        self.pushEvent(.close);
     }
     return false;
 }


### PR DESCRIPTION
If this isn't the behavior you want, feel free to just close this. Just a simple change that sets `shouldClose` to false, which should defer actually closing the app to the user, handling the `close` event and returning true from `update`. The use case here is if an app wants to show a dialog box to confirm closing the application and offer a way of cancelling the close.

- [X] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.