### PR TITLE
core: Ensure that the BitSet is large enough to handle all…

### DIFF
--- a/src/InputState.zig
+++ b/src/InputState.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const core = @import("main.zig");
-const KeyBitSet = std.StaticBitSet(@intFromEnum(core.Key.max));
-const MouseButtonSet = std.StaticBitSet(@intFromEnum(core.MouseButton.max));
+const KeyBitSet = std.StaticBitSet(@intFromEnum(core.Key.max) + 1);
+const MouseButtonSet = std.StaticBitSet(@as(u4, @intFromEnum(core.MouseButton.max)) + 1);
 const InputState = @This();
 
 keys: KeyBitSet = KeyBitSet.initEmpty(),


### PR DESCRIPTION
… enum values

Closes https://github.com/hexops/mach/issues/938.

Please close if I'm handling this incorrectly, but my thoughts here are that the error is specifying below:
```
/Users/foxnne/.zvm/master/lib/std/bit_set.zig:483:19: 0x1028fd1bf in unset (pixi)
            assert(index < bit_length);
```

With that assert comparison being `less than` rather than `less than or equal`, setting the bitset to the size of the max enum value size would never be large enough to handle `unknown` value for `Key`. Just setting it to be one bit larger seems to fix the issue, though you might have a better fix in mind? 

- [ x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.