### PR TITLE
free some gpu objects

### DIFF
--- a/src/platform/native/Core.zig
+++ b/src/platform/native/Core.zig
@@ -521,6 +521,10 @@ pub fn deinit(self: *Core) void {
         self.linux_gamemode != null and
         self.linux_gamemode.?)
         deinitLinuxGamemode();
+
+    self.surface.release();
+    self.gpu_adapter.release();
+    self.instance.release();
 }
 
 // Secondary app-update thread


### PR DESCRIPTION
freeing device will call `deviceLostCallback`. that probably means we are ignoring an in-use object. most examples are also not releasing gpu objects (e.g. pipeline in triangle example)



- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.