### PR TITLE
Begin supporting independent DGPU/WGPU API choice

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -103,7 +103,6 @@ pub const App = struct {
             src: []const u8,
             target: std.zig.CrossTarget,
             optimize: std.builtin.OptimizeMode,
-            use_dusk: bool = false,
             custom_entrypoint: ?[]const u8 = null,
             deps: ?[]const std.build.ModuleDependency = null,
             res_dirs: ?[]const []const u8 = null,
@@ -115,9 +114,6 @@ pub const App = struct {
         const platform = Platform.fromTarget(target);
 
         var dependencies = std.ArrayList(std.build.ModuleDependency).init(app_builder.allocator);
-
-        const build_options = app_builder.addOptions();
-        build_options.addOption(bool, "use_dusk", options.use_dusk);
 
         const mach_core_mod = options.mach_core_mod orelse app_builder.dependency("mach_core", .{
             .target = options.target,
@@ -164,7 +160,6 @@ pub const App = struct {
 
         if (options.custom_entrypoint == null) compile.main_pkg_path = .{ .path = sdkPath("/src") };
         compile.addModule("mach-core", mach_core_mod);
-        compile.addModule("build-options", build_options.createModule());
         compile.addModule("app", app_module);
 
         // Installation step

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -19,12 +19,12 @@
             .hash = "12207678927df42d7895a72fc220a5a18e21f241b42ca6cb6c1c3004a54bdd314d1d",
         },
         .mach_dusk = .{
-            .url = "https://pkg.machengine.org/mach-dusk/b9ba7bd7bc5325b9176e9e2328a457b0add09703.tar.gz",
+            .url = "https://pkg.machengine.org/mach-dusk/64afe9043d06a221073516218c42260019605df2.tar.gz",
             .hash = "1220628b984ef4cf2d6c358dc01ed6ffd0cd13701d6bf4f498f080c9e72cd633821f",
         },
         .mach_gpu = .{
-            .url = "https://pkg.machengine.org/mach-gpu/46d62d5c63f524228edeba06c7bb38f0015272cc.tar.gz",
-            .hash = "12209e517b8b459b95fb66f045580a66f8901970e7416f2ae90613df63adb710e19c",
+            .url = "https://pkg.machengine.org/mach-gpu/26c9273ab19ebd0368c0a598907943f2c5ed1f73.tar.gz",
+            .hash = "1220f784698f085674f8c083e9a58728772e35b563c88c43eaecae94bba15cbf2655",
         },
         .mach_glfw = .{
             .url = "https://pkg.machengine.org/mach-glfw/321efd4065b57e31d8ab0bce720852c1d680d443.tar.gz",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -19,8 +19,8 @@
             .hash = "12207678927df42d7895a72fc220a5a18e21f241b42ca6cb6c1c3004a54bdd314d1d",
         },
         .mach_dusk = .{
-            .url = "https://pkg.machengine.org/mach-dusk/64afe9043d06a221073516218c42260019605df2.tar.gz",
-            .hash = "1220628b984ef4cf2d6c358dc01ed6ffd0cd13701d6bf4f498f080c9e72cd633821f",
+            .url = "https://pkg.machengine.org/mach-dusk/f7602a391c3d2cd1e9beb6c7b05a80c3e6f2d2ba.tar.gz",
+            .hash = "12205200384a28668d260e0864ac66ccb2135e7b8837ed0b3c7e3a005645a6871e5a",
         },
         .mach_gpu = .{
             .url = "https://pkg.machengine.org/mach-gpu/26c9273ab19ebd0368c0a598907943f2c5ed1f73.tar.gz",

--- a/examples/dusk/triangle/main.zig
+++ b/examples/dusk/triangle/main.zig
@@ -1,0 +1,96 @@
+const std = @import("std");
+const core = @import("mach-core");
+const gpu = core.gpu;
+
+pub const App = @This();
+
+pub const mach_core_options = core.ComptimeOptions{
+    .use_wgpu = false,
+    .use_dgpu = true,
+};
+
+title_timer: core.Timer,
+pipeline: *gpu.RenderPipeline,
+
+pub fn init(app: *App) !void {
+    try core.init(.{});
+
+    const shader_module = core.device.createShaderModuleWGSL("shader.wgsl", @embedFile("shader.wgsl"));
+    defer shader_module.release();
+
+    // Fragment state
+    const blend = gpu.BlendState{};
+    const color_target = gpu.ColorTargetState{
+        .format = core.descriptor.format,
+        .blend = &blend,
+        .write_mask = gpu.ColorWriteMaskFlags.all,
+    };
+    const fragment = gpu.FragmentState.init(.{
+        .module = shader_module,
+        .entry_point = "frag_main",
+        .targets = &.{color_target},
+    });
+    const pipeline_descriptor = gpu.RenderPipeline.Descriptor{
+        .fragment = &fragment,
+        .vertex = gpu.VertexState{
+            .module = shader_module,
+            .entry_point = "vertex_main",
+        },
+    };
+    const pipeline = core.device.createRenderPipeline(&pipeline_descriptor);
+
+    app.* = .{ .title_timer = try core.Timer.start(), .pipeline = pipeline };
+}
+
+pub fn deinit(app: *App) void {
+    defer core.deinit();
+    app.pipeline.release();
+}
+
+pub fn update(app: *App) !bool {
+    var iter = core.pollEvents();
+    while (iter.next()) |event| {
+        switch (event) {
+            .close => return true,
+            else => {},
+        }
+    }
+
+    const queue = core.queue;
+    const back_buffer_view = core.swap_chain.getCurrentTextureView().?;
+    const color_attachment = gpu.RenderPassColorAttachment{
+        .view = back_buffer_view,
+        .clear_value = std.mem.zeroes(gpu.Color),
+        .load_op = .clear,
+        .store_op = .store,
+    };
+
+    const encoder = core.device.createCommandEncoder(null);
+    const render_pass_info = gpu.RenderPassDescriptor.init(.{
+        .color_attachments = &.{color_attachment},
+    });
+    const pass = encoder.beginRenderPass(&render_pass_info);
+    pass.setPipeline(app.pipeline);
+    pass.draw(3, 1, 0, 0);
+    pass.end();
+    pass.release();
+
+    var command = encoder.finish(null);
+    encoder.release();
+
+    queue.submit(&[_]*gpu.CommandBuffer{command});
+    command.release();
+    core.swap_chain.present();
+    back_buffer_view.release();
+
+    // update the window title every second
+    if (app.title_timer.read() >= 1.0) {
+        app.title_timer.reset();
+        try core.printTitle("Triangle [ {d}fps ] [ Input {d}hz ]", .{
+            core.frameRate(),
+            core.inputRate(),
+        });
+    }
+
+    return false;
+}

--- a/examples/dusk/triangle/shader.wgsl
+++ b/examples/dusk/triangle/shader.wgsl
@@ -1,0 +1,14 @@
+@vertex fn vertex_main(
+    @builtin(vertex_index) VertexIndex : u32
+) -> @builtin(position) vec4<f32> {
+    var pos = array<vec2<f32>, 3>(
+        vec2<f32>( 0.0,  0.5),
+        vec2<f32>(-0.5, -0.5),
+        vec2<f32>( 0.5, -0.5)
+    );
+    return vec4<f32>(pos[VertexIndex], 0.0, 1.0);
+}
+
+@fragment fn frag_main() -> @location(0) vec4<f32> {
+    return vec4<f32>(1.0, 0.0, 0.0, 1.0);
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
 const builtin = @import("builtin");
 
-pub const gpu = @import("mach-gpu");
 pub const dusk = @import("mach-dusk");
 pub const sysjs = @import("mach-sysjs");
 pub const Timer = @import("Timer.zig");
@@ -13,6 +12,32 @@ const platform = @import("platform.zig");
 fn ErrorSet(comptime F: type) type {
     return @typeInfo(@typeInfo(F).Fn.return_type.?).ErrorUnion.error_set;
 }
+
+/// Comptime options that you can configure in your main file by writing e.g.:
+///
+/// ```
+/// pub const mach_core_options = core.ComptimeOptions{
+///     .use_wgpu = true,
+///     .use_dgpu = true,
+/// };
+/// ```
+pub const ComptimeOptions = struct {
+    /// Whether to use
+    use_wgpu: bool = true,
+
+    /// Whether or not to use the experimental Dusk graphics API.
+    use_dgpu: bool = false,
+};
+
+pub const options = if (@hasDecl(@import("root"), "mach_core_options"))
+    @import("root").mach_core_options
+else
+    ComptimeOptions{};
+
+pub const wgpu = @import("mach-gpu");
+pub const dgpu = dusk.dgpu;
+
+pub const gpu = if (options.use_dgpu) dgpu else wgpu;
 
 pub fn AppInterface(comptime app_entry: anytype) void {
     if (!@hasDecl(app_entry, "App")) {
@@ -111,9 +136,9 @@ pub const Options = struct {
     required_limits: ?gpu.Limits = null,
 };
 
-pub fn init(options: Options) !void {
+pub fn init(options_in: Options) !void {
     // Copy window title into owned buffer.
-    var opt = options;
+    var opt = options_in;
     if (opt.title.len < title.len) {
         std.mem.copy(u8, title[0..], opt.title);
         title[opt.title.len] = 0;

--- a/src/platform/native/Core.zig
+++ b/src/platform/native/Core.zig
@@ -1,8 +1,8 @@
 const builtin = @import("builtin");
 const std = @import("std");
-const gpu = @import("mach-gpu");
 const glfw = @import("mach-glfw");
 const mach_core = @import("../../main.zig");
+const gpu = mach_core.gpu;
 const util = @import("util.zig");
 const Options = @import("../../main.zig").Options;
 const Event = @import("../../main.zig").Event;
@@ -136,7 +136,8 @@ pub fn init(
     input: *Frequency,
     options: Options,
 ) !void {
-    if (!@import("builtin").is_test) _ = gpu.Export(@import("root").GPUInterface);
+    if (!@import("builtin").is_test and mach_core.options.use_wgpu) _ = mach_core.wgpu.Export(@import("root").GPUInterface);
+    if (!@import("builtin").is_test and mach_core.options.use_dgpu) _ = mach_core.dgpu.Export(@import("root").DGPUInterface);
 
     const backend_type = try util.detectBackendType(allocator);
 

--- a/src/platform/native/util.zig
+++ b/src/platform/native/util.zig
@@ -1,7 +1,8 @@
 const std = @import("std");
 
 const glfw = @import("mach-glfw");
-const gpu = @import("mach-gpu");
+const mach_core = @import("../../main.zig");
+const gpu = mach_core.gpu;
 const objc = @import("objc_message.zig");
 
 pub inline fn printUnhandledErrorCallback(_: void, typ: gpu.ErrorType, message: [*:0]const u8) void {

--- a/src/platform/wasm/Core.zig
+++ b/src/platform/wasm/Core.zig
@@ -1,8 +1,8 @@
 const std = @import("std");
-const gpu = @import("mach-gpu");
 const js = @import("js.zig");
 const Timer = @import("Timer.zig");
 const mach_core = @import("../../main.zig");
+const gpu = mach_core.gpu;
 const Options = @import("../../main.zig").Options;
 const Event = @import("../../main.zig").Event;
 const KeyEvent = @import("../../main.zig").KeyEvent;
@@ -252,7 +252,7 @@ pub fn init(
         .joysticks = std.mem.zeroes([JoystickData.max_joysticks]JoystickData),
     };
 
-    // TODO(wasm): webgpu support
+    // TODO(wasm): wgpu support
     mach_core.adapter = undefined;
     mach_core.device = undefined;
     mach_core.queue = undefined;


### PR DESCRIPTION
## Beginning of a render graph style API

This pairs with https://github.com/hexops/mach-dusk/pull/81 and is the first step in having Dusk graduate from being a WGPU implementation.. to being a WGPU competitor, which can use WGPU behind the scenes as one of its backends.

![image](https://github.com/hexops/mach-dusk/assets/3173176/7d382603-e4f8-4448-ae48-2b3a9292ae96)

## Deciding when/how DGPU (Dusk graphics API) or WGPU (Dawn/browser) should be used

Whether or not to use Dusk is no longer a build option. Instead, it's comptime configuration we can specify in `main.zig` via a magic declaration:

```zig
pub const mach_core_options = core.ComptimeOptions{
    .use_wgpu = false,
    .use_dgpu = true,
};
```

The default is to only `.use_wgpu = true,` for now, meaning mach-core behaves the same way as before and uses Dawn. In this case, `mach_core.gpu` refers to `mach-gpu`, the WebGPU API.

When `.use_dgpu = true`, `mach_core.gpu` refers to `dusk.dgpu` - the new Render Graph style API which we will begin to define after this PR. When `.use_dgpu = true`, `.use_wgpu` refers to whether or not a WebGPU backend (Dawn or browser's) should be built into the binary. i.e. we can disable this for a pure-Dusk binary, or enable it for Dawn usage and greater hardware compatibility. Ultimately Dusk's `dgpu.Interface` would be responsible for deciding whether to use WebGPU, though. For example, if D3D12 is not supported Dusk could fall back to Dawn.

## Example layout

Dusk examples now go into `examples/dusk/` and since they will be using a different graphics API than WebGPU.

## Device initialization

For now, mach-core doesn't do anything special to initialize the device between WGPU/DGPU. They share the same API for now. Keep in mind _both_ may be initialized in the same program, as DGPU may use WGPU as one of its backends.

## Known issues

triangle-msaa and rotating-cube for Dusk don't exist yet.

`zig build run-dusk-triangle` doesn't actually run yet. It builds, but does not run. This is because Dusk is still returning `gpu` objects, which refer to the global `gpu.Impl` which is `null` as only DGPU is in use. We will need to replace references in Dusk to `gpu.Foo` with `dgpu.Foo`

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.