### PR TITLE
update for newest build system API

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -141,6 +141,7 @@ pub const App = struct {
                     .root_source_file = .{ .path = options.custom_entrypoint orelse sdkPath("/src/platform/wasm/main.zig") },
                     .target = options.target,
                     .optimize = options.optimize,
+                    .main_mod_path = if (options.custom_entrypoint == null) .{ .path = sdkPath("/src") } else null,
                 });
                 lib.rdynamic = true;
 
@@ -151,6 +152,7 @@ pub const App = struct {
                     .root_source_file = .{ .path = options.custom_entrypoint orelse sdkPath("/src/platform/native/main.zig") },
                     .target = options.target,
                     .optimize = options.optimize,
+                    .main_mod_path = if (options.custom_entrypoint == null) .{ .path = sdkPath("/src") } else null,
                 });
                 // TODO(core): figure out why we need to disable LTO: https://github.com/hexops/mach/issues/597
                 exe.want_lto = false;
@@ -158,7 +160,6 @@ pub const App = struct {
             }
         };
 
-        if (options.custom_entrypoint == null) compile.main_pkg_path = .{ .path = sdkPath("/src") };
         compile.addModule("mach-core", mach_core_mod);
         compile.addModule("app", app_module);
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -31,4 +31,15 @@
             .hash = "122002e355cf42b8d257efc95229c9ee6be4cca189c1718f86179cb7c21225beeb75",
         },
     },
+    .paths = .{
+        "build_examples.zig",
+        "build.zig",
+        "build.zig.zon",
+        "examples",
+        "LICENSE",
+        "LICENSE-APACHE",
+        "LICENSE-MIT",
+        "README.md",
+        "src",
+    },
 }


### PR DESCRIPTION
This gets mach-core compiling again after https://github.com/ziglang/zig/pull/17392

Or, you can change `main_mod_path` to `main_pkg_path`, to use the deprecated field name, and the code will work for older zig versions too. The deprecated field will get removed just before 0.12.0 is released.

With the package manager rework branch, I measured `zig build --fetch` taking 1.6 seconds on my machine, with master branch clocking in at 31 seconds.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.