### PR TITLE
Enable the toggle 'allow unsafe apis'

### DIFF
--- a/src/platform/native/Core.zig
+++ b/src/platform/native/Core.zig
@@ -233,6 +233,14 @@ pub fn init(
 
     // Create a device with default limits/features.
     const gpu_device = response.adapter.?.createDevice(&.{
+        .next_in_chain = .{
+            .dawn_toggles_descriptor = &gpu.dawn.TogglesDescriptor.init(.{
+                .enabled_toggles = &[_][*:0]const u8{
+                    "allow_unsafe_apis",
+                },
+            }),
+        },
+
         .required_features_count = if (options.required_features) |v| @as(u32, @intCast(v.len)) else 0,
         .required_features = if (options.required_features) |v| @as(?[*]const gpu.FeatureName, v.ptr) else null,
         .required_limits = if (options.required_limits) |limits| @as(?*const gpu.RequiredLimits, &gpu.RequiredLimits{


### PR DESCRIPTION
The toggle `allow_unsafe_apis` is disabled by default. This change enables it by default.
Without `allow_unsafe_apis`, [writeTimestamp](https://github.com/hexops/mach-gpu/blob/main/src/render_pass_encoder.zig#L117) will fail with a validation error.
My use case for `allow_unsafe_apis` is to allow gpu timestamp profiling. In particular, I used this feature to integrate [tracy](https://github.com/wolfpld/tracy) gpu profiling into my program. 
The reason why this is disabled by default (to my knowledge) is to prevent [timing attacks](https://en.wikipedia.org/wiki/Timing_attack), but I doubt that's a concern for mach.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.