### PR TITLE
windows: add ability to access underlying native window handle

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -80,6 +80,7 @@ pub fn AppInterface(comptime app_entry: anytype) void {
     }
 }
 
+
 /// wasm32: custom std.log implementation which logs to the browser console.
 /// other: std.log.defaultLog
 pub const defaultLog = platform.Core.defaultLog;
@@ -457,6 +458,13 @@ pub inline fn inputRate() u32 {
 /// May only be called on macOS.
 pub fn nativeWindowCocoa() *anyopaque {
     return internal.nativeWindowCocoa();
+}
+
+/// Returns the underlying native Windows' HWND pointer
+///
+/// May only be called on Windows.
+pub fn nativeWindowWin32() std.os.windows.HWND {
+    return internal.nativeWindowWin32();
 }
 
 pub const Size = struct {

--- a/src/platform/native/Core.zig
+++ b/src/platform/native/Core.zig
@@ -1045,6 +1045,12 @@ pub fn nativeWindowCocoa(self: *Core) *anyopaque {
     return glfw_native.getCocoaWindow(self.window).?;
 }
 
+// May be called from any thread.
+pub fn nativeWindowWin32(self: *Core) std.os.windows.HWND {
+    const glfw_native = glfw.Native(comptime util.detectGLFWOptions());
+    return glfw_native.getWin32Window(self.window);
+}
+
 fn toMachButton(button: glfw.mouse_button.MouseButton) MouseButton {
     return switch (button) {
         .left => .left,


### PR DESCRIPTION

This change allows for users to access the windows handle form the core library. This is part of https://github.com/hexops/mach/issues/1115 
- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.