### PR TITLE
Revert "avoid autodoc segfault; helps hexops/mach#1145"

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -59,16 +59,13 @@ pub fn build(b: *std.Build) !void {
         const test_step = b.step("test", "run tests");
         test_step.dependOn(&b.addRunArtifact(main_tests).step);
 
-        // TODO: autodoc segfaults the build if we have this enabled
-        // https://github.com/hexops/mach/issues/1145
-        //
-        // const install_docs = b.addInstallDirectory(.{
-        //     .source_dir = main_tests.getEmittedDocs(),
-        //     .install_dir = .prefix, // default build output prefix, ./zig-out
-        //     .install_subdir = "docs",
-        // });
-        // const docs_step = b.step("docs", "Generate API docs");
-        // docs_step.dependOn(&install_docs.step);
+        const install_docs = b.addInstallDirectory(.{
+            .source_dir = main_tests.getEmittedDocs(),
+            .install_dir = .prefix, // default build output prefix, ./zig-out
+            .install_subdir = "docs",
+        });
+        const docs_step = b.step("docs", "Generate API docs");
+        docs_step.dependOn(&install_docs.step);
     }
 
     try @import("build_examples.zig").build(b, optimize, target, module);


### PR DESCRIPTION
This branch reproduces the autodoc segfault described in hexops/mach#1145

To run it:

* Use this Zig version: https://machengine.org/about/nominated-zig/#202410-mach
* Clone the repo and checkout this branch
* `zig build docs`
* Observe the segfault in the compiler / autodoc described in hexops/mach#1145

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.