### PR TITLE
re-enable sysgpu support; helps hexops/mach#1144

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -11,17 +11,15 @@ pub fn build(b: *std.Build) !void {
         .target = target,
         .optimize = optimize,
     });
-    // TODO(sysgpu): re-enable, see https://github.com/hexops/mach/issues/1144
-    // const sysgpu_dep = b.dependency("mach_sysgpu", .{
-    //     .target = target,
-    //     .optimize = optimize,
-    // });
+    const sysgpu_dep = b.dependency("mach_sysgpu", .{
+        .target = target,
+        .optimize = optimize,
+    });
     const module = b.addModule("mach-core", .{
         .root_source_file = .{ .path = "src/main.zig" },
         .imports = &.{
             .{ .name = "mach-gpu", .module = mach_gpu_dep.module("mach-gpu") },
-            // TODO(sysgpu): re-enable, see https://github.com/hexops/mach/issues/1144
-            // .{ .name = "mach-sysgpu", .module = sysgpu_dep.module("mach-sysgpu") },
+            .{ .name = "mach-sysgpu", .module = sysgpu_dep.module("mach-sysgpu") },
         },
     });
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -32,11 +32,10 @@
             .url = "https://pkg.machengine.org/mach-gamemode/36b4d973c9d15dfc214d0b901c174c206bb5f4dc.tar.gz",
             .hash = "12203aaefcb85324476a6d3d277451ea1feaac3549641d717c631a3cffd38eecfbda",
         },
-        // TODO(sysgpu): re-enable, see https://github.com/hexops/mach/issues/1144
-        // .mach_sysgpu = .{
-        //     .url = "https://pkg.machengine.org/mach-sysgpu/4f60121ce6803bde7695aefb8cb8647d05c2a714.tar.gz",
-        //     .hash = "1220468021e8ad528defe092cc36ad4342555d2106482781665e8672c9e3345b5d6b",
-        // },
+        .mach_sysgpu = .{
+            .url = "https://pkg.machengine.org/mach-sysgpu/4f60121ce6803bde7695aefb8cb8647d05c2a714.tar.gz",
+            .hash = "1220468021e8ad528defe092cc36ad4342555d2106482781665e8672c9e3345b5d6b",
+        },
         .mach_gpu = .{
             .url = "https://pkg.machengine.org/mach-gpu/47244d1e216284a3389bd42af431f59f39a8f67e.tar.gz",
             .hash = "1220e77a3e8386f57f73685026e43a17385ec8b3fb6e9873c9c793defd30651cfa09",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -33,8 +33,8 @@
             .hash = "12203aaefcb85324476a6d3d277451ea1feaac3549641d717c631a3cffd38eecfbda",
         },
         .mach_sysgpu = .{
-            .url = "https://pkg.machengine.org/mach-sysgpu/df42bc81173adfa97945c483cf2d0ff71db8bb51.tar.gz",
-            .hash = "1220123655c38b2f967d75cce52485697606b4621c0084c51f1c7872ee5360e77bde",
+            .url = "https://pkg.machengine.org/mach-sysgpu/d6ed118f54c4784f7ce01b70fc1b94f887fae1a8.tar.gz",
+            .hash = "1220fba810cecf1e1f9ff89a0a08d4eca64fa682e52e0480d3e8dfbf0dd91746ae51",
         },
         .mach_gpu = .{
             .url = "https://pkg.machengine.org/mach-gpu/47244d1e216284a3389bd42af431f59f39a8f67e.tar.gz",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -33,8 +33,8 @@
             .hash = "12203aaefcb85324476a6d3d277451ea1feaac3549641d717c631a3cffd38eecfbda",
         },
         .mach_sysgpu = .{
-            .url = "https://pkg.machengine.org/mach-sysgpu/4f60121ce6803bde7695aefb8cb8647d05c2a714.tar.gz",
-            .hash = "1220468021e8ad528defe092cc36ad4342555d2106482781665e8672c9e3345b5d6b",
+            .url = "https://pkg.machengine.org/mach-sysgpu/df42bc81173adfa97945c483cf2d0ff71db8bb51.tar.gz",
+            .hash = "1220123655c38b2f967d75cce52485697606b4621c0084c51f1c7872ee5360e77bde",
         },
         .mach_gpu = .{
             .url = "https://pkg.machengine.org/mach-gpu/47244d1e216284a3389bd42af431f59f39a8f67e.tar.gz",

--- a/build_examples.zig
+++ b/build_examples.zig
@@ -152,15 +152,6 @@ pub fn build(
             else => {},
         };
 
-        if (example.sysgpu) {
-            const sysgpu_dep = b.dependency("mach_sysgpu", .{
-                .target = target,
-                .optimize = optimize,
-            });
-            app.compile.linkLibrary(sysgpu_dep.artifact("mach-sysgpu"));
-            @import("mach_sysgpu").addPaths(app.compile);
-        }
-
         const install_step = b.step(cmd_name, "Install " ++ cmd_name);
         install_step.dependOn(&app.install.step);
         b.getInstallStep().dependOn(install_step);

--- a/build_examples.zig
+++ b/build_examples.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
 const core = @import("build.zig");
-// TODO(sysgpu): re-enable, see https://github.com/hexops/mach/issues/1144
-// const sysgpu = @import("mach_sysgpu");
+const sysgpu = @import("mach_sysgpu");
 
 pub fn build(
     b: *std.Build,
@@ -83,28 +82,28 @@ pub fn build(
         .{ .name = "image-blur", .deps = &.{ .zigimg, .assets } },
         .{ .name = "cubemap", .deps = &.{ .zigimg, .assets } },
 
-        // // sysgpu
-        // .{ .name = "boids", .sysgpu = true },
-        // .{ .name = "clear-color", .sysgpu = true },
-        // .{ .name = "cubemap", .deps = &.{ .zigimg, .assets }, .sysgpu = true },
-        // .{ .name = "deferred-rendering", .deps = &.{ .model3d, .assets }, .std_platform_only = true, .sysgpu = true },
-        // .{ .name = "fractal-cube", .sysgpu = true },
-        // .{ .name = "gen-texture-light", .sysgpu = true },
-        // .{ .name = "image-blur", .deps = &.{ .zigimg, .assets }, .sysgpu = true },
-        // .{ .name = "instanced-cube", .sysgpu = true },
-        // .{ .name = "map-async", .sysgpu = true },
-        // .{ .name = "pbr-basic", .deps = &.{ .model3d, .assets }, .std_platform_only = true, .sysgpu = true },
-        // .{ .name = "pixel-post-process", .sysgpu = true },
-        // .{ .name = "procedural-primitives", .sysgpu = true },
-        // .{ .name = "rotating-cube", .sysgpu = true },
-        // .{ .name = "sprite2d", .deps = &.{ .zigimg, .assets }, .sysgpu = true },
-        // .{ .name = "image", .deps = &.{ .zigimg, .assets }, .sysgpu = true },
-        // .{ .name = "textured-cube", .deps = &.{ .zigimg, .assets }, .sysgpu = true },
-        // .{ .name = "textured-quad", .deps = &.{ .zigimg, .assets }, .sysgpu = true },
-        // .{ .name = "triangle", .sysgpu = true },
-        // .{ .name = "triangle-msaa", .sysgpu = true },
-        // .{ .name = "two-cubes", .sysgpu = true },
-        // .{ .name = "rgb-quad", .sysgpu = true },
+        // sysgpu
+        .{ .name = "boids", .sysgpu = true },
+        .{ .name = "clear-color", .sysgpu = true },
+        .{ .name = "cubemap", .deps = &.{ .zigimg, .assets }, .sysgpu = true },
+        .{ .name = "deferred-rendering", .deps = &.{ .model3d, .assets }, .std_platform_only = true, .sysgpu = true },
+        .{ .name = "fractal-cube", .sysgpu = true },
+        .{ .name = "gen-texture-light", .sysgpu = true },
+        .{ .name = "image-blur", .deps = &.{ .zigimg, .assets }, .sysgpu = true },
+        .{ .name = "instanced-cube", .sysgpu = true },
+        .{ .name = "map-async", .sysgpu = true },
+        .{ .name = "pbr-basic", .deps = &.{ .model3d, .assets }, .std_platform_only = true, .sysgpu = true },
+        .{ .name = "pixel-post-process", .sysgpu = true },
+        .{ .name = "procedural-primitives", .sysgpu = true },
+        .{ .name = "rotating-cube", .sysgpu = true },
+        .{ .name = "sprite2d", .deps = &.{ .zigimg, .assets }, .sysgpu = true },
+        .{ .name = "image", .deps = &.{ .zigimg, .assets }, .sysgpu = true },
+        .{ .name = "textured-cube", .deps = &.{ .zigimg, .assets }, .sysgpu = true },
+        .{ .name = "textured-quad", .deps = &.{ .zigimg, .assets }, .sysgpu = true },
+        .{ .name = "triangle", .sysgpu = true },
+        .{ .name = "triangle-msaa", .sysgpu = true },
+        .{ .name = "two-cubes", .sysgpu = true },
+        .{ .name = "rgb-quad", .sysgpu = true },
     }) |example| {
         // FIXME: this is workaround for a problem that some examples
         // (having the std_platform_only=true field) as well as zigimg
@@ -153,15 +152,14 @@ pub fn build(
             else => {},
         };
 
-        // TODO(sysgpu): re-enable, see https://github.com/hexops/mach/issues/1144
-        // if (example.sysgpu) {
-        //     const sysgpu_dep = b.dependency("mach_sysgpu", .{
-        //         .target = target,
-        //         .optimize = optimize,
-        //     });
-        //     app.compile.linkLibrary(sysgpu_dep.artifact("mach-sysgpu"));
-        //     @import("mach_sysgpu").addPaths(app.compile);
-        // }
+        if (example.sysgpu) {
+            const sysgpu_dep = b.dependency("mach_sysgpu", .{
+                .target = target,
+                .optimize = optimize,
+            });
+            app.compile.linkLibrary(sysgpu_dep.artifact("mach-sysgpu"));
+            @import("mach_sysgpu").addPaths(app.compile);
+        }
 
         const install_step = b.step(cmd_name, "Install " ++ cmd_name);
         install_step.dependOn(&app.install.step);

--- a/examples/sysgpu/procedural-primitives/procedural-primitives.zig
+++ b/examples/sysgpu/procedural-primitives/procedural-primitives.zig
@@ -111,7 +111,7 @@ pub fn createCirclePrimitive(allocator: std.mem.Allocator, vertices: u32, radius
     vertex_data.appendAssumeCapacity(VertexData{ .position = F32x3{ 0, 0, 0.0 }, .normal = F32x3{ 0, 0, 0.0 } });
 
     var x: u32 = 0;
-    var angle = 2 * PI / @as(f32, @floatFromInt(vertices));
+    const angle = 2 * PI / @as(f32, @floatFromInt(vertices));
     while (x < vertices) : (x += 1) {
         const x_f = @as(f32, @floatFromInt(x));
         const pos_x = radius * zmath.cos(angle * x_f);
@@ -203,7 +203,7 @@ pub fn createCylinderPrimitive(allocator: std.mem.Allocator, radius: f32, height
     const angle = 2.0 * PI / @as(f32, @floatFromInt(num_sides));
 
     for (1..num_sides + 1) |i| {
-        var float_i = @as(f32, @floatFromInt(i));
+        const float_i = @as(f32, @floatFromInt(i));
 
         const x: f32 = radius * zmath.sin(angle * float_i);
         const y: f32 = radius * zmath.cos(angle * float_i);
@@ -230,18 +230,18 @@ pub fn createCylinderPrimitive(allocator: std.mem.Allocator, radius: f32, height
     {
         var i: u32 = 0;
         while (i < alloc_amt_idx) : (i += 3) {
-            var indexA: u32 = index_data.items[i];
-            var indexB: u32 = index_data.items[i + 1];
-            var indexC: u32 = index_data.items[i + 2];
+            const indexA: u32 = index_data.items[i];
+            const indexB: u32 = index_data.items[i + 1];
+            const indexC: u32 = index_data.items[i + 2];
 
-            var vert1: F32x4 = F32x4{ vertex_data.get(indexA).position[0], vertex_data.get(indexA).position[1], vertex_data.get(indexA).position[2], 1.0 };
-            var vert2: F32x4 = F32x4{ vertex_data.get(indexB).position[0], vertex_data.get(indexB).position[1], vertex_data.get(indexB).position[2], 1.0 };
-            var vert3: F32x4 = F32x4{ vertex_data.get(indexC).position[0], vertex_data.get(indexC).position[1], vertex_data.get(indexC).position[2], 1.0 };
+            const vert1: F32x4 = F32x4{ vertex_data.get(indexA).position[0], vertex_data.get(indexA).position[1], vertex_data.get(indexA).position[2], 1.0 };
+            const vert2: F32x4 = F32x4{ vertex_data.get(indexB).position[0], vertex_data.get(indexB).position[1], vertex_data.get(indexB).position[2], 1.0 };
+            const vert3: F32x4 = F32x4{ vertex_data.get(indexC).position[0], vertex_data.get(indexC).position[1], vertex_data.get(indexC).position[2], 1.0 };
 
-            var edgeAB: F32x4 = vert2 - vert1;
-            var edgeAC: F32x4 = vert3 - vert1;
+            const edgeAB: F32x4 = vert2 - vert1;
+            const edgeAC: F32x4 = vert3 - vert1;
 
-            var cross = zmath.cross3(edgeAB, edgeAC);
+            const cross = zmath.cross3(edgeAB, edgeAC);
 
             vertex_data.items(.normal)[indexA][0] += cross[0];
             vertex_data.items(.normal)[indexA][1] += cross[1];
@@ -279,7 +279,7 @@ pub fn createConePrimitive(allocator: std.mem.Allocator, radius: f32, height: f3
     const angle = 2.0 * PI / @as(f32, @floatFromInt(num_sides));
 
     for (1..num_sides + 1) |i| {
-        var float_i = @as(f32, @floatFromInt(i));
+        const float_i = @as(f32, @floatFromInt(i));
 
         const x: f32 = radius * zmath.sin(angle * float_i);
         const y: f32 = radius * zmath.cos(angle * float_i);
@@ -303,18 +303,18 @@ pub fn createConePrimitive(allocator: std.mem.Allocator, radius: f32, height: f3
     {
         var i: u32 = 0;
         while (i < alloc_amt_idx) : (i += 3) {
-            var indexA: u32 = index_data.items[i];
-            var indexB: u32 = index_data.items[i + 1];
-            var indexC: u32 = index_data.items[i + 2];
+            const indexA: u32 = index_data.items[i];
+            const indexB: u32 = index_data.items[i + 1];
+            const indexC: u32 = index_data.items[i + 2];
 
-            var vert1: F32x4 = F32x4{ vertex_data.get(indexA).position[0], vertex_data.get(indexA).position[1], vertex_data.get(indexA).position[2], 1.0 };
-            var vert2: F32x4 = F32x4{ vertex_data.get(indexB).position[0], vertex_data.get(indexB).position[1], vertex_data.get(indexB).position[2], 1.0 };
-            var vert3: F32x4 = F32x4{ vertex_data.get(indexC).position[0], vertex_data.get(indexC).position[1], vertex_data.get(indexC).position[2], 1.0 };
+            const vert1: F32x4 = F32x4{ vertex_data.get(indexA).position[0], vertex_data.get(indexA).position[1], vertex_data.get(indexA).position[2], 1.0 };
+            const vert2: F32x4 = F32x4{ vertex_data.get(indexB).position[0], vertex_data.get(indexB).position[1], vertex_data.get(indexB).position[2], 1.0 };
+            const vert3: F32x4 = F32x4{ vertex_data.get(indexC).position[0], vertex_data.get(indexC).position[1], vertex_data.get(indexC).position[2], 1.0 };
 
-            var edgeAB: F32x4 = vert2 - vert1;
-            var edgeAC: F32x4 = vert3 - vert1;
+            const edgeAB: F32x4 = vert2 - vert1;
+            const edgeAC: F32x4 = vert3 - vert1;
 
-            var cross = zmath.cross3(edgeAB, edgeAC);
+            const cross = zmath.cross3(edgeAB, edgeAC);
 
             vertex_data.items(.normal)[indexA][0] += cross[0];
             vertex_data.items(.normal)[indexA][1] += cross[1];


### PR DESCRIPTION
The goal of this change is to get sysgpu building again.

Currently it fails with an obscure error:

```
install
└─ sysgpu-deferred-rendering
   └─ install sysgpu-deferred-rendering
      └─ zig build-exe sysgpu-deferred-rendering Debug native failure
error: error: unable to add module 'mach-gpu': already exists as 'main.zig'

error: the following command exited with error code 1:
```

Which probably indicates a bug in sysgpu's build.zig logic, but unclear.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.