### PR TITLE
remove unnecessary checks

### DIFF
--- a/src/platform/native/main.zig
+++ b/src/platform/native/main.zig
@@ -29,8 +29,7 @@ pub fn main() !void {
     core.allocator = gpa.allocator();
 
     // Initialize GPU implementation
-    if (comptime core.options.use_wgpu) try core.wgpu.Impl.init(core.allocator, .{});
-    if (comptime core.options.use_sysgpu) try core.sysgpu.Impl.init(core.allocator, .{});
+    try core.gpu.Impl.init(core.allocator, .{});
 
     var app: App = undefined;
     try app.init();


### PR DESCRIPTION
- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.

Since the `gpu` is already set as the graphics library to use, (in `mach-core/src/main.zig`) it's redundant to check here also.